### PR TITLE
Support SSH agent authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ This allows you to use the same configuration template across multiple workspace
 | `baseDir` | string | `"/"` | Local base directory for uploads |
 | `privateKey` | string | `null` | Path to private key file for key-based authentication |
 | `passphrase` | string | `null` | Passphrase for encrypted private key |
+| `useAuthAgent` | bool | `false` | Enable authentication over SSH auth agent |
+| `authAgentPath` | string | `${env.SSH_AUTH_SOCK}` | Path of the SSH agent socket |
 
 ## Extension Commands
 

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -27,6 +27,8 @@ export class Configs {
                 baseDir: "/",
                 privateKey: null,
                 passphrase: null,
+                useAuthAgent: true,
+                authAgentPath: "/path/to/auth/agent",
             },
             {
                 name: "My FTP",

--- a/src/targets/Interfaces.ts
+++ b/src/targets/Interfaces.ts
@@ -29,6 +29,8 @@ export interface TargetOptionsInterface {
     privateKey?: string;
     passphrase?: string;
     transferDataType?: "binary" | "ascii";
+    useAuthAgent?: boolean;
+    authAgentPath?: string;
 }
 
 export interface TargetInterface {

--- a/src/targets/SFTP.ts
+++ b/src/targets/SFTP.ts
@@ -175,11 +175,20 @@ export class SFTP extends Target implements TargetInterface {
         Extension.appendLineToOutputChannel(
             "[INFO][SFTP] Connecting to: " + this.options.host + ":" + this.options.port
         );
+        if (!this.options.authAgentPath) {
+            this.options.authAgentPath = process.env.SSH_AUTH_SOCK || undefined;
+        }
         if (!this.options.useAuthAgent) {
             this.options.useAuthAgent = false;
         }
+        if(this.options.useAuthAgent && !this.options.authAgentPath) {
+            Extension.appendLineToOutputChannel(
+                "[WARN][SFTP] Auth agent is enabled but no auth agent path is set."
+            );
+            this.options.useAuthAgent = false;
+        }
         Extension.appendLineToOutputChannel(
-            "[INFO][SFTP] Auth agent: " + (this.options.useAuthAgent ? ("Enabled (" + this.options.authAgentPath || process.env.SSH_AUTH_SOCK + ")") : "Disabled")
+            "[INFO][SFTP] Auth agent: " + (this.options.useAuthAgent ? ("Enabled (" + this.options.authAgentPath + ")") : "Disabled")
         );
         this.client.connect({
             host: this.options.host,
@@ -189,7 +198,7 @@ export class SFTP extends Target implements TargetInterface {
             privateKey: privateKey,
             passphrase: this.options.passphrase,
             tryKeyboard: true, // Enable keyboard-interactive fallback
-            agent: this.options.useAuthAgent ? (this.options.authAgentPath || process.env.SSH_AUTH_SOCK) : undefined,
+            agent: this.options.useAuthAgent ? (this.options.authAgentPath) : undefined,
         });
     }
     upload(uri: vscode.Uri): Promise<vscode.Uri> {

--- a/src/targets/SFTP.ts
+++ b/src/targets/SFTP.ts
@@ -8,6 +8,7 @@ import { Configs } from "../configs";
 import EventEmitter = require("events");
 import { Targets } from "./Targets";
 import { Target } from "./Target";
+import * as process from "process";
 
 export class SFTP extends Target implements TargetInterface {
     private client = new ssh2.Client();
@@ -174,6 +175,12 @@ export class SFTP extends Target implements TargetInterface {
         Extension.appendLineToOutputChannel(
             "[INFO][SFTP] Connecting to: " + this.options.host + ":" + this.options.port
         );
+        if (!this.options.useAuthAgent) {
+            this.options.useAuthAgent = false;
+        }
+        Extension.appendLineToOutputChannel(
+            "[INFO][SFTP] Auth agent: " + (this.options.useAuthAgent ? ("Enabled (" + this.options.authAgentPath || process.env.SSH_AUTH_SOCK + ")") : "Disabled")
+        );
         this.client.connect({
             host: this.options.host,
             port: this.options.port,
@@ -182,6 +189,7 @@ export class SFTP extends Target implements TargetInterface {
             privateKey: privateKey,
             passphrase: this.options.passphrase,
             tryKeyboard: true, // Enable keyboard-interactive fallback
+            agent: this.options.useAuthAgent ? (this.options.authAgentPath || process.env.SSH_AUTH_SOCK) : undefined,
         });
     }
     upload(uri: vscode.Uri): Promise<vscode.Uri> {


### PR DESCRIPTION
Adds a configuration property to enable SSH agent authentication. Disabled by default. 
Reads the SSH agent socket path from env.SSH_AUTH_SOCK (which is standard across other SSH-related apps), but also allows overriding the path from the configuration file.

I never dealt with VSCode extensions, so you should have a closer look at the code :)