### PR TITLE
fix: config reload lags one save behind

### DIFF
--- a/src/configs.ts
+++ b/src/configs.ts
@@ -215,6 +215,12 @@ export class Configs {
                     this.configs = VariableResolver.resolveObject(this.configs, workspaceFolder);
                 }
 
+                // Keep the workspaceConfigs map (used by getAllTargetOptions) in sync synchronously,
+                // otherwise cb() rebuilds targets from the previous save's data (lags one save behind).
+                if (workspaceFolder) {
+                    this.workspaceConfigs[workspaceFolder.uri.path + "/.vscode/pro-deployer.json"] = this.configs;
+                }
+
                 Extension.appendLineToOutputChannel(
                     "[INFO] The config file is updated: " + JSON.stringify(this.configs),
                 );


### PR DESCRIPTION
Fixes #58.

### Problem

`pro-deployer.json` changes lag **one save behind**: the first save after an edit applies the *previous* config, and a second save is needed to flush it through. Very noticeable with `files.autoSave`.

### Root cause

In `src/configs.ts`, the `onDidSaveTextDocument` handler keeps two stores:

- `this.configs` — updated synchronously from `e.getText()`.
- `this.workspaceConfigs` — the per-folder map that `getAllTargetOptions()` reads to rebuild targets and the picker.

Block 1 updates only `this.configs`, then immediately calls `cb()` (rebuild from `getAllTargetOptions()` → reads `this.workspaceConfigs`). But `this.workspaceConfigs` is only refreshed by Block 2's **async** `readFile`, which resolves *after* `cb()` already ran — so the rebuild uses the previous save's data.

### Fix

Sync `workspaceConfigs` for the saved file synchronously, before `cb()`:

```ts
if (workspaceFolder) {
    this.workspaceConfigs[workspaceFolder.uri.path + "/.vscode/pro-deployer.json"] = this.configs;
}
```

One line, no behavior change other than removing the lag. Block 2's async reload stays as-is (now redundant for the active file, harmless).

### Testing

- `npm run compile` — clean.
- Packaged a VSIX, installed over 3.5.0 on Windows 11 with `files.autoSave: afterDelay`.
- Renamed a target, waited for a single autosave, ran **Upload To** → picker shows the new name immediately. Output log now shows `target is created` with the new value in the **same** cycle as `config file is updated`. Confirmed the lag is gone.
