### PR TITLE
fix: avoid 'mkdir .' on upload recovery for root-level files

### DIFF
--- a/src/targets/FTP.ts
+++ b/src/targets/FTP.ts
@@ -183,7 +183,8 @@ export class FTP extends Target implements TargetInterface {
                             "[ERROR][FTP] Can't upload file: " + uri.path + ". Error: " + err.message
                         );
 
-                        const dir = this.options.dir + path.dirname(relativePath);
+                        const dirName = path.dirname(relativePath);
+                        const dir = this.options.dir + (dirName === "." ? "" : dirName);
                         this.mkdir(dir).then(
                             () => {
                                 this.client.put(uri.fsPath, this.options.dir + relativePath, (err) => {


### PR DESCRIPTION
Fixes #60.

### Problem

When an upload's first `put` fails and the file is at the **root of `baseDir`**, the directory-recovery path calls `mkdir` on a path ending in `.`. The `ftp` lib's recursive `mkdir` then issues `MKD .` → `.: File exists`, which **masks the real upload error** (e.g. `ECONNRESET`) and can create an unintended directory tree on the server.

### Root cause

`src/targets/FTP.ts`:

```ts
const dir = this.options.dir + path.dirname(relativePath);
```

For a root-level file, `path.dirname(relativePath) === "."` and `this.options.dir` ends with `/`, producing `/home/user/public_html/.`.

### Fix

```ts
const dirName = path.dirname(relativePath);
const dir = this.options.dir + (dirName === "." ? "" : dirName);
```

One line; only the `.`-segment case changes. Subdirectory uploads are unaffected (`path.dirname("foo/bar.php") === "foo"`).

### Testing

- `npm run compile` — clean.
- Packaged a VSIX, installed on Windows 11 against a ProFTPD server.
- Uploaded a file at the root of `baseDir`: the spurious `.: File exists` is gone; when the first attempt fails, the log now shows the real underlying error instead of the fake mkdir one. Subdirectory uploads continue to create the correct remote dirs.
